### PR TITLE
Using public git URL so installer does not need a github account

### DIFF
--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ setup_data.version }}
 
 source:
-  git_url: git@github.com:jeremy-large/CODiT.git
+  git_url: git://github.com/jeremy-large/CODiT.git
   git_rev: {{ setup_data.version }}
 
 requirements:


### PR DESCRIPTION
@jeremy-large This should allow anyone to install CODiT, ie also people without a github account